### PR TITLE
looser dependency constraints for highest compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "require": {
     "launchdarkly/server-sdk": "3.*",
-    "guzzlehttp/guzzle": "6.2.1",
-    "kevinrob/guzzle-cache-middleware": "1.4.1",
+    "guzzlehttp/guzzle": "6.*",
+    "kevinrob/guzzle-cache-middleware": "1.*",
     "predis/predis": "1.0.*"
   }
 }


### PR DESCRIPTION
With this change, I no longer get the message `count(): Parameter must be an array or an object that implements Countable in ./vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 67` when running in PHP 7.3, which came from using [too old a version of Guzzle](https://github.com/guzzle/guzzle/issues/1973).