### PR TITLE
fix: remediate high & critical Dependabot and Wiz vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "require": {
     "launchdarkly/server-sdk": ">=6.0",
     "guzzlehttp/guzzle": "7.*",
+    "guzzlehttp/psr7": ">=2.10.2",
     "kevinrob/guzzle-cache-middleware": "^7.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds `guzzlehttp/psr7: >=2.10.2` as an explicit direct dependency to enforce a minimum safe version, remediating two open Dependabot/Wiz alerts:

- **CRLF Injection via URI Host Component** (`guzzlehttp/psr7 < 2.10.2`)
- **Host Confusion via Authority Reinterpretation** (`guzzlehttp/psr7 < 2.10.2`)

`guzzlehttp/psr7` is a transitive dependency of `guzzlehttp/guzzle`. Since Composer has no override mechanism, adding it as a direct requirement with a version floor is the standard approach to prevent resolution of vulnerable versions.

Verified via `composer install` that dependencies resolve to `guzzlehttp/psr7@2.11.0` and the app runs correctly.

Link to Devin session: https://app.devin.ai/sessions/e07439e1d3664b9dbfebd4ba7954a13c
Requested by: @pkaeding