### PR TITLE
chore: update server-sdk from >=6.0 to >=6.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "launchdarkly/server-sdk": ">=6.0",
+    "launchdarkly/server-sdk": ">=6.8.1",
     "guzzlehttp/guzzle": "7.*",
     "kevinrob/guzzle-cache-middleware": "^7.0"
   }


### PR DESCRIPTION
## Summary

Updates the `launchdarkly/server-sdk` version constraint in `composer.json` from `>=6.0` to `>=6.8.1`.

No deprecated APIs were found in the example code. The application was tested successfully with SDK 6.8.1 — flag evaluation works as expected.

Link to Devin session: https://app.devin.ai/sessions/6ee6d365f0174aec92aff40d1bf065e0
Requested by: @kinyoklion